### PR TITLE
feat: create `migrator` model

### DIFF
--- a/models/migrator.js
+++ b/models/migrator.js
@@ -1,0 +1,63 @@
+import migrationRunner from "node-pg-migrate";
+import { resolve } from "node:path";
+import database from "infra/database.js";
+import { ServiceError } from "infra/errors.js";
+
+const defaultMigrationOptions = {
+  dryRun: true,
+  dir: resolve("infra", "migrations"),
+  direction: "up",
+  verbose: true,
+  migrationsTable: "pgmigrations",
+};
+
+async function listPendingMigrations() {
+  let dbClient;
+
+  try {
+    dbClient = await database.getNewClient();
+
+    const pendingMigrations = await migrationRunner({
+      ...defaultMigrationOptions,
+      dbClient,
+    });
+    return pendingMigrations;
+  } catch (error) {
+    throw new ServiceError({
+      message: "Erro ao listar migrations pendentes.",
+      cause: error,
+    });
+  } finally {
+    await dbClient?.end();
+  }
+}
+
+async function runPendingMigrations() {
+  let dbClient;
+
+  try {
+    dbClient = await database.getNewClient();
+
+    const migratedMigrations = await migrationRunner({
+      ...defaultMigrationOptions,
+      dbClient,
+      dryRun: false,
+    });
+
+    return migratedMigrations;
+  } catch (error) {
+    throw new ServiceError({
+      message: "Erro ao executar migrations",
+      cause: error,
+    });
+  } finally {
+    await dbClient?.end();
+  }
+}
+
+const migrator = {
+  listPendingMigrations,
+  runPendingMigrations,
+};
+
+export default migrator;

--- a/pages/api/v1/migrations/index.js
+++ b/pages/api/v1/migrations/index.js
@@ -1,8 +1,6 @@
 import { createRouter } from "next-connect";
-import migrationRunner from "node-pg-migrate";
-import { resolve } from "node:path";
-import database from "infra/database.js";
 import controller from "infra/controller.js";
+import migrator from "models/migrator.js";
 
 const router = createRouter();
 
@@ -11,48 +9,17 @@ router.post(postHandler);
 
 export default router.handler(controller.errorHandlers);
 
-const defaultMigrationOptions = {
-  dryRun: true,
-  dir: resolve("infra", "migrations"),
-  direction: "up",
-  verbose: true,
-  migrationsTable: "pgmigrations",
-};
-
 async function getHandler(request, response) {
-  let dbClient;
-
-  try {
-    dbClient = await database.getNewClient();
-
-    const pendingMigrations = await migrationRunner({
-      ...defaultMigrationOptions,
-      dbClient,
-    });
-    return response.status(200).json(pendingMigrations);
-  } finally {
-    await dbClient.end();
-  }
+  const pendingMigrations = await migrator.listPendingMigrations();
+  return response.status(200).json(pendingMigrations);
 }
 
 async function postHandler(request, response) {
-  let dbClient;
+  const migratedMigrations = await migrator.runPendingMigrations();
 
-  try {
-    dbClient = await database.getNewClient();
-
-    const migratedMigrations = await migrationRunner({
-      ...defaultMigrationOptions,
-      dbClient,
-      dryRun: false,
-    });
-
-    if (migratedMigrations.length > 0) {
-      return response.status(201).json(migratedMigrations);
-    }
-
-    return response.status(200).json(migratedMigrations);
-  } finally {
-    await dbClient.end();
+  if (migratedMigrations.length > 0) {
+    return response.status(201).json(migratedMigrations);
   }
+
+  return response.status(200).json(migratedMigrations);
 }


### PR DESCRIPTION
This pull request introduces a new `migrator` module to handle database migrations and refactors the existing API to use this module. The changes improve code organization and error handling.

Refactoring for better code organization:

* [`models/migrator.js`](diffhunk://#diff-675d499137a25966b668d68462918d2f2a81bc97e643002db2eaedf4920396d0R1-R63): Created a new `migrator` module to encapsulate migration logic, including functions `listPendingMigrations` and `runPendingMigrations`, and default migration options.
* [`pages/api/v1/migrations/index.js`](diffhunk://#diff-c140e431fa82defe6ecd0f6bea8f1e318394e6210718a42c7bbc5482af6519edL2-R3): Replaced direct usage of migration logic with calls to the new `migrator` module, simplifying the API handlers for listing and running migrations. [[1]](diffhunk://#diff-c140e431fa82defe6ecd0f6bea8f1e318394e6210718a42c7bbc5482af6519edL2-R3) [[2]](diffhunk://#diff-c140e431fa82defe6ecd0f6bea8f1e318394e6210718a42c7bbc5482af6519edL14-L57)